### PR TITLE
fix flatland challenge deadline

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
             "name": "Flatland Challenge",
             "url": "https://www.aicrowd.com/challenges/flatland-challenge",
             "type": "Reinforcement Learning",
-            "deadline": "22 Jan 2020",
+            "deadline": "5 Jan 2020",
             "prize": "$30,000",
             "platform": "AIcrowd",
             "sponsor": "Swiss Federal Railways (SBB)"


### PR DESCRIPTION
https://www.aicrowd.com/challenges/flatland-challenge#rounds says

> Round 2 open now and will close on Sunday, 5th of January 2020, 12 PM. UTC +1