### PR TITLE
Add Open link in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
         }]
 
         function make_href(url, text) {
-            return '<a href="' + url + '">' + text + '</a>';
+            return '<a href="' + url + '" target="_blank">' + text + '</a>';
         }
 
         function days_until_deadline(deadline) {
@@ -424,14 +424,14 @@
                 </thead>
             </table>
             <p class="text-center " style="font-style: italic; margin-top:2em; ">
-                Use code <a href="https://paperspace.io/&R=ZKGRZB5 ">ZKGRZB5</a> to get $10 free credit at <a href="https://paperspace.io/&R=ZKGRZB5 ">Paperspace</a>, and easily deploy your training scripts to their cheap cloud GPUs.
+                Use code <a href="https://paperspace.io/&R=ZKGRZB5 " target="_blank">ZKGRZB5</a> to get $10 free credit at <a href="https://paperspace.io/&R=ZKGRZB5 " target="_blank">Paperspace</a>, and easily deploy your training scripts to their cheap cloud GPUs.
             </p>
         </div>
     </div>
 
     <footer class="page-footer " style="margin-top:3em; padding-bottom:0.5em ">
         <div class="container-fluid text-center ">
-            &copy; 2020 ML Contests. Submit changes or requests on <a href="https://github.com/mlcontests/mlcontests.github.io " style="color:black; font-weight:bold; ">GitHub</a>.
+            &copy; 2020 ML Contests. Submit changes or requests on <a href="https://github.com/mlcontests/mlcontests.github.io "  target="_blank" style="color:black; font-weight:bold; ">GitHub</a>.
         </div>
     </footer>
 


### PR DESCRIPTION
It is much easier to open multiple links at once if someone forgets to press CTRL or ⌘ & This also keeps sorting order intact for the user at a particular time. 