### PR TITLE
GNNet Challenge: deadline extended

### DIFF
--- a/js/competitions.json
+++ b/js/competitions.json
@@ -108,7 +108,7 @@
          "name": "Graph Neural Networking Challenge 2021",
          "url": "https://bnn.upc.edu/challenge/gnnet2021",
          "type": "☋ Graph Learning",
-         "deadline": "31 Aug 2021",
+         "deadline": "14 Sep 2021",
          "prize": "$5,500",
          "platform": "BNN-UPC",
          "sponsor": "ITU/United Nations/Xilinx"


### PR DESCRIPTION
Graph Neural Networking Challenge 2021: deadline extended to Sep 14th