### PR TITLE
Add Coder One

### DIFF
--- a/js/competitions.json
+++ b/js/competitions.json
@@ -1,5 +1,14 @@
  {
      "data": [
+        {
+            "name": "Coder One",
+            "url": "https://www.gocoder.one/?s=mlc",
+            "type": "🤖 Reinforcement Learning",
+            "deadline": "14 Sep 2022",
+            "prize": "$5,000",
+            "platform": "Coder One",
+            "sponsor": "SitePoint, General Assembly, Hackathons Australia"
+        },
       {
             "name": "Identify beluga Whales from Images",
             "url": "https://www.drivendata.org/competitions/96/beluga-whales/",


### PR DESCRIPTION
Hi!

Coder One is an AI programming competition but we have tools + resources (e.g. gym) for participants that want to apply reinforcement learning also.

We have an entry fee for the competition (although the environment is completely free and open-source to use). I created an entry code `MLCONTESTS100` that is redeemable for free entry. Wondering if maybe you could share that info on the Discord or mailing list directly, since there isn't a spot for it on the website?

Thank you! 😊