### PR TITLE
Update traffic4cast deadline

### DIFF
--- a/js/competitions.json
+++ b/js/competitions.json
@@ -286,7 +286,7 @@
             "name": "Traffic4cast",
             "url": "https://www.iarai.ac.at/traffic4cast/",
             "type": "📈 Time Series Forecasting",
-            "deadline": "15 Oct 2022",
+            "deadline": "24 Oct 2022",
             "prize": "$10,000",
             "platform": "IARAI",
             "sponsor": null,


### PR DESCRIPTION
The ongoing traffic4cast competition deadline got extended, refer to here: https://github.com/iarai/NeurIPS2022-traffic4cast#competition-timeline .