### PR TITLE
add new deep learning competition antares

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -4831,7 +4831,15 @@
         "prize": "$6,600",
         "platform": "Humyn.ai",
         "sponsor": null
+      }, {
+        "name": "From One to Many: A Generative AI Challenge",
+        "url": "https://xeek.ai/challenges/from-one-to-many",
+        "type": "Generative Neural Network",
+        "tags": ["ann", "dl", "gan", "cvae"],
+        "deadline": "15 July 2023",
+        "prize": "$25,000",
+        "platform": "Xeek",
+        "sponsor": null
       }
      ]
-
  }

--- a/competitions.json
+++ b/competitions.json
@@ -4832,11 +4832,13 @@
         "platform": "Humyn.ai",
         "sponsor": null
       }, {
-        "name": "From One to Many: A Generative AI Challenge",
-        "url": "https://xeek.ai/challenges/from-one-to-many",
-        "type": "Generative Neural Network",
-        "tags": ["ann", "dl", "gan", "cvae"],
-        "deadline": "15 July 2023",
+        "name": "Train a Conditional VAE to Produce Inputs to Mathematical Functions",
+        "url": "https://xeek.ai/challenges/from-one-to-many?ref=mlcontests",
+        "type": "💭 Generative Models",
+        "tags": ["deeplearning", "generative", "measurable"],
+        "launched": "2 Jun 2023",
+        "registration-deadline": "15 Jul 2023",
+        "deadline": "15 Jul 2023",
         "prize": "$25,000",
         "platform": "Xeek",
         "sponsor": null


### PR DESCRIPTION
Hi. We are starting a new Generative Neural Network challenge in Xeek very soon.
I didn't find `Generative Neural Network` in types as well as `["ann", "dl", "gan", "cvae"]` in tags. Can we add them, please?
Thanks.