### PR TITLE
Antigranular: Harvard Open DP Hackathon

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -1,15 +1,16 @@
 {
     "data": [
         {
-            "name": "Antigranular: Harvard Open DP Hackathon",
+            "name": "Privacy-Preserving Data Sharing for Pandemic Management",
             "url": "https://www.antigranular.com/competitions/6512bb40e5a926ede026c129",
-            "type": "🔗 Private Probabilistic Record Linkage",
+            "type": "🕵 Privacy",
             "tags": [
                 "privacy",
                 "classification",
-                "data"
+                "measurable",
+                "supervised"
             ],
-            "additional_urls": ["https://www.antigranular.com/competitions/6512bb40e5a926ede026c129"],
+            "additional_urls": [],
             "launched": "1 Oct 2023",
             "registration-deadline": "30 Dec 2023",
             "deadline": "30 Dec 2023",

--- a/competitions.json
+++ b/competitions.json
@@ -1,6 +1,26 @@
 {
     "data": [
-         {
+        {
+            "name": "Antigranular: Harvard Open DP Hackathon",
+            "url": "https://www.antigranular.com/competitions/6512bb40e5a926ede026c129",
+            "type": "🔗 Private Probabilistic Record Linkage",
+            "tags": [
+                "privacy",
+                "classification",
+                "data"
+            ],
+            "additional_urls": ["https://www.antigranular.com/competitions/6512bb40e5a926ede026c129"],
+            "launched": "1 Oct 2023",
+            "registration-deadline": "30 Dec 2023",
+            "deadline": "30 Dec 2023",
+            "prize": "$5,500",
+            "platform": "Antigranular",
+            "sponsor": "OpenDP",
+            "conference": null,
+            "conference-year": null
+        
+        },
+        {
             "name": "Water Supply Forecast Rodeo",
             "url": "https://www.drivendata.org/competitions/group/reclamation-water-supply-forecast/?ref=mlcontests",
             "type": "📈 Time Series Forecasting",


### PR DESCRIPTION
We are currently running an "Eyes-Off Data Science Competition" on Antigranular in collaboration with the team at OpenDP (Harvard) to mark their community meeting this year. More details at: https://www.antigranular.com/competitions/6512bb40e5a926ede026c129