### PR TITLE
Add competition: BirdCLEF+ 2025

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -3377,6 +3377,25 @@
       "sponsor": "Brigham Young University",
       "conference": null,
       "conference_year": null
+    },
+    {
+      "name": "BirdCLEF+ 2025",
+      "url": "https://www.kaggle.com/competitions/birdclef-2025?ref=mlcontests",
+      "tags": [
+        "earth and nature",
+        "animals",
+        "multilabel classification",
+        "audio event classification",
+        "custom metric"
+      ],
+      "launched": "10 Mar 2025",
+      "registration-deadline": "29 May 2025",
+      "deadline": "5 Jun 2025",
+      "prize": "$50,000",
+      "platform": "Kaggle",
+      "sponsor": "Cornell Lab of Ornithology",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -3379,14 +3379,14 @@
       "conference_year": null
     },
     {
-      "name": "BirdCLEF+ 2025",
+      "name": "BirdCLEF+ 2025: Identify Animal Species From Audio",
       "url": "https://www.kaggle.com/competitions/birdclef-2025?ref=mlcontests",
       "tags": [
-        "earth and nature",
-        "animals",
-        "multilabel classification",
-        "audio event classification",
-        "custom metric"
+        "science",
+        "audio",
+        "classification",
+        "measurable",
+        "supervised"
       ],
       "launched": "10 Mar 2025",
       "registration-deadline": "29 May 2025",


### PR DESCRIPTION
Competition: 

```{'name': 'BirdCLEF+ 2025', 'url': 'https://www.kaggle.com/competitions/birdclef-2025?ref=mlcontests', 'tags': ['earth and nature', 'animals', 'multilabel classification', 'audio event classification', 'custom metric'], 'launched': '10 Mar 2025', 'registration-deadline': '29 May 2025', 'deadline': '5 Jun 2025', 'prize': '$50,000', 'platform': 'Kaggle', 'sponsor': 'Cornell Lab of Ornithology', 'conference': None, 'conference_year': None}```