### PR TITLE
Add competition: ARC Prize 2025

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -41,7 +41,9 @@
       "prize": "$50,000",
       "platform": "Pond",
       "sponsor": "Vitalik Buterin, DeepFunding, OSObserver, Allo Capital, Drips Network, Pairwisevote",
-      "additional_urls": ["https://www.deepfunding.org/"],
+      "additional_urls": [
+        "https://www.deepfunding.org/"
+      ],
       "conference": null,
       "conference_year": null
     },
@@ -3438,6 +3440,22 @@
       "prize": "$12,000",
       "platform": "Solafune",
       "sponsor": null
+    },
+    {
+      "name": "ARC Prize 2025",
+      "url": "https://www.kaggle.com/competitions/arc-prize-2025?ref=mlcontests",
+      "tags": [
+        "artificial intelligence",
+        "custom metric"
+      ],
+      "launched": "26 Mar 2025",
+      "registration-deadline": "27 Oct 2025",
+      "deadline": "3 Nov 2025",
+      "prize": "$725,000",
+      "platform": "Kaggle",
+      "sponsor": "Abstraction and Reasoning Corpus",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }


### PR DESCRIPTION
Competition: 

```{'name': 'ARC Prize 2025', 'url': 'https://www.kaggle.com/competitions/arc-prize-2025?ref=mlcontests', 'tags': ['artificial intelligence', 'custom metric'], 'launched': '26 Mar 2025', 'registration-deadline': '27 Oct 2025', 'deadline': '3 Nov 2025', 'prize': '$725,000', 'platform': 'Kaggle', 'sponsor': 'Abstraction and Reasoning Corpus', 'conference': None, 'conference_year': None}```