### PR TITLE
Add competition: NeurIPS - Open Polymer Prediction 2025

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -3909,12 +3909,14 @@
       "conference_year": null
     },
     {
-      "name": "NeurIPS - Open Polymer Prediction 2025",
+      "name": "Predict Fundamental Properties of Polymers",
       "url": "https://www.kaggle.com/competitions/neurips-open-polymer-prediction-2025?ref=mlcontests",
       "tags": [
         "chemistry",
-        "science and technology",
-        "custom metric"
+        "science",
+        "measurable",
+        "regression",
+        "supervised"
       ],
       "launched": "16 Jun 2025",
       "registration-deadline": "8 Sep 2025",
@@ -3922,8 +3924,8 @@
       "prize": "$50,000",
       "platform": "Kaggle",
       "sponsor": "University of Notre Dame",
-      "conference": null,
-      "conference_year": null
+      "conference": "NeurIPS",
+      "conference_year": 2025
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -3907,7 +3907,23 @@
       "sponsor": "Make Data Count",
       "conference": null,
       "conference_year": null
+    },
+    {
+      "name": "NeurIPS - Open Polymer Prediction 2025",
+      "url": "https://www.kaggle.com/competitions/neurips-open-polymer-prediction-2025?ref=mlcontests",
+      "tags": [
+        "chemistry",
+        "science and technology",
+        "custom metric"
+      ],
+      "launched": "16 Jun 2025",
+      "registration-deadline": "8 Sep 2025",
+      "deadline": "15 Sep 2025",
+      "prize": "$50,000",
+      "platform": "Kaggle",
+      "sponsor": "University of Notre Dame",
+      "conference": null,
+      "conference_year": null
     }
-    
   ]
 }


### PR DESCRIPTION
Competition: 

```{'name': 'NeurIPS - Open Polymer Prediction 2025', 'url': 'https://www.kaggle.com/competitions/neurips-open-polymer-prediction-2025?ref=mlcontests', 'tags': ['chemistry', 'science and technology', 'custom metric'], 'launched': '16 Jun 2025', 'registration-deadline': '8 Sep 2025', 'deadline': '15 Sep 2025', 'prize': '$50,000', 'platform': 'Kaggle', 'sponsor': 'University of Notre Dame', 'conference': None, 'conference_year': None}```