### PR TITLE
Add competition: MAP - Charting Student Math Misunderstandings

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -4147,13 +4147,12 @@
       "conference_year": null
     },
     {
-      "name": "MAP - Charting Student Math Misunderstandings",
+      "name": "Identify Students' Math Misunderstandings",
       "url": "https://www.kaggle.com/competitions/map-charting-student-math-misunderstandings?ref=mlcontests",
       "tags": [
         "education",
         "nlp",
-        "primary and secondary schools",
-        "map@{k}"
+        "classification"
       ],
       "launched": "10 Jul 2025",
       "registration-deadline": "8 Oct 2025",


### PR DESCRIPTION
Competition: 

```{'name': 'MAP - Charting Student Math Misunderstandings', 'url': 'https://www.kaggle.com/competitions/map-charting-student-math-misunderstandings?ref=mlcontests', 'tags': ['education', 'nlp', 'primary and secondary schools', 'map@{k}'], 'launched': '10 Jul 2025', 'registration-deadline': '8 Oct 2025', 'deadline': '15 Oct 2025', 'prize': '$55,000', 'platform': 'Kaggle', 'sponsor': 'The Learning Agency Lab', 'conference': None, 'conference_year': None}```