### PR TITLE
Add competition: MITSUI&CO. Commodity Prediction Challenge

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -4320,12 +4320,15 @@
       "conference_year": null
     },
     {
-      "name": "MITSUI&CO. Commodity Prediction Challenge",
+      "name": "Predict Commodity Price Movements",
       "url": "https://www.kaggle.com/competitions/mitsui-commodity-prediction-challenge?ref=mlcontests",
       "tags": [
         "finance",
-        "investing",
-        "custom metric"
+        "regression",
+        "supervised",
+        "timeseries",
+        "forecasting",
+        "measurable"
       ],
       "launched": "24 Jul 2025",
       "registration-deadline": "29 Sep 2025",

--- a/competitions.json
+++ b/competitions.json
@@ -4318,6 +4318,23 @@
       "sponsor": "Jigsaw/Conversation AI",
       "conference": null,
       "conference_year": null
+    },
+    {
+      "name": "MITSUI&CO. Commodity Prediction Challenge",
+      "url": "https://www.kaggle.com/competitions/mitsui-commodity-prediction-challenge?ref=mlcontests",
+      "tags": [
+        "finance",
+        "investing",
+        "custom metric"
+      ],
+      "launched": "24 Jul 2025",
+      "registration-deadline": "29 Sep 2025",
+      "deadline": "6 Oct 2025",
+      "prize": "$100,000",
+      "platform": "Kaggle",
+      "sponsor": "MITSUI & CO., LTD.",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }


### PR DESCRIPTION
Competition: 

```{'name': 'MITSUI&CO. Commodity Prediction Challenge', 'url': 'https://www.kaggle.com/competitions/mitsui-commodity-prediction-challenge?ref=mlcontests', 'tags': ['finance', 'investing', 'custom metric'], 'launched': '24 Jul 2025', 'registration-deadline': '29 Sep 2025', 'deadline': '6 Oct 2025', 'prize': '$100,000', 'platform': 'Kaggle', 'sponsor': 'MITSUI & CO., LTD.', 'conference': None, 'conference_year': None}```