### PR TITLE
Add competition: Hull Tactical - Market Prediction

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -4552,12 +4552,15 @@
       "conference_year": null
     },
     {
-      "name": "Hull Tactical - Market Prediction",
+      "name": "Predict Daily Stock Index Returns",
       "url": "https://www.kaggle.com/competitions/hull-tactical-market-prediction?ref=mlcontests",
       "tags": [
         "finance",
         "tabular",
-        "custom metric"
+        "timeseries",
+        "forecasting"
+        "supervised",
+        "regression"
       ],
       "launched": "16 Sep 2025",
       "registration-deadline": "8 Dec 2025",

--- a/competitions.json
+++ b/competitions.json
@@ -4550,6 +4550,23 @@
       "sponsor": "Google Cloud",
       "conference": null,
       "conference_year": null
+    },
+    {
+      "name": "Hull Tactical - Market Prediction",
+      "url": "https://www.kaggle.com/competitions/hull-tactical-market-prediction?ref=mlcontests",
+      "tags": [
+        "finance",
+        "tabular",
+        "custom metric"
+      ],
+      "launched": "16 Sep 2025",
+      "registration-deadline": "8 Dec 2025",
+      "deadline": "15 Dec 2025",
+      "prize": "$100,000",
+      "platform": "Kaggle",
+      "sponsor": "Hull Tactical",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -4679,7 +4679,7 @@
         "finance",
         "tabular",
         "timeseries",
-        "forecasting"
+        "forecasting",
         "supervised",
         "regression"
       ],


### PR DESCRIPTION
Competition: 

```{'name': 'Hull Tactical - Market Prediction', 'url': 'https://www.kaggle.com/competitions/hull-tactical-market-prediction?ref=mlcontests', 'tags': ['finance', 'tabular', 'custom metric'], 'launched': '16 Sep 2025', 'registration-deadline': '8 Dec 2025', 'deadline': '15 Dec 2025', 'prize': '$100,000', 'platform': 'Kaggle', 'sponsor': 'Hull Tactical', 'conference': None, 'conference_year': None}```