### PR TITLE
Add 2 new competitions from Kaggle

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -4922,6 +4922,39 @@
       "sponsor": "MABe Challenge",
       "conference": null,
       "conference_year": null
+    },
+    {
+      "name": "NFL Big Data Bowl 2026 - Analytics",
+      "url": "https://www.kaggle.com/competitions/nfl-big-data-bowl-2026-analytics?ref=mlcontests",
+      "tags": [
+        "football",
+        "sports"
+      ],
+      "launched": "25 Sep 2025",
+      "registration-deadline": null,
+      "deadline": "17 Dec 2025",
+      "prize": "$50,000",
+      "platform": "Kaggle",
+      "sponsor": "The National Football League",
+      "conference": null,
+      "conference_year": null
+    },
+    {
+      "name": "NFL Big Data Bowl 2026 - Prediction",
+      "url": "https://www.kaggle.com/competitions/nfl-big-data-bowl-2026-prediction?ref=mlcontests",
+      "tags": [
+        "football",
+        "sports",
+        "custom metric"
+      ],
+      "launched": "25 Sep 2025",
+      "registration-deadline": "26 Nov 2025",
+      "deadline": "3 Dec 2025",
+      "prize": "$50,000",
+      "platform": "Kaggle",
+      "sponsor": "The National Football League",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -4927,32 +4927,36 @@
       "name": "NFL Big Data Bowl 2026 - Analytics",
       "url": "https://www.kaggle.com/competitions/nfl-big-data-bowl-2026-analytics?ref=mlcontests",
       "tags": [
-        "football",
-        "sports"
+        "analysis/visualisation",
+        "sports",
+        "writing",
+        "subjective"
       ],
       "launched": "25 Sep 2025",
       "registration-deadline": null,
       "deadline": "17 Dec 2025",
       "prize": "$50,000",
       "platform": "Kaggle",
-      "sponsor": "The National Football League",
+      "sponsor": "The NFL,
       "conference": null,
       "conference_year": null
     },
     {
-      "name": "NFL Big Data Bowl 2026 - Prediction",
+      "name": "Predict NFL Player Movement",
       "url": "https://www.kaggle.com/competitions/nfl-big-data-bowl-2026-prediction?ref=mlcontests",
       "tags": [
-        "football",
         "sports",
-        "custom metric"
+        "regression",
+        "measurable",
+        "supervised",
+        "timeseries"
       ],
       "launched": "25 Sep 2025",
       "registration-deadline": "26 Nov 2025",
       "deadline": "3 Dec 2025",
       "prize": "$50,000",
       "platform": "Kaggle",
-      "sponsor": "The National Football League",
+      "sponsor": "The NFL",
       "conference": null,
       "conference_year": null
     }

--- a/competitions.json
+++ b/competitions.json
@@ -4924,7 +4924,7 @@
       "conference_year": null
     },
     {
-      "name": "NFL Big Data Bowl 2026 - Analytics",
+      "name": "Analyse NFL Player Movement Data",
       "url": "https://www.kaggle.com/competitions/nfl-big-data-bowl-2026-analytics?ref=mlcontests",
       "tags": [
         "analysis/visualisation",

--- a/competitions.json
+++ b/competitions.json
@@ -4937,7 +4937,7 @@
       "deadline": "17 Dec 2025",
       "prize": "$50,000",
       "platform": "Kaggle",
-      "sponsor": "The NFL,
+      "sponsor": "The NFL",
       "conference": null,
       "conference_year": null
     },


### PR DESCRIPTION
Add 2 competitions: 
 - NFL Big Data Bowl 2026 - Analytics
 - NFL Big Data Bowl 2026 - Prediction

```[{'name': 'NFL Big Data Bowl 2026 - Analytics', 'url': 'https://www.kaggle.com/competitions/nfl-big-data-bowl-2026-analytics?ref=mlcontests', 'tags': ['football', 'sports'], 'launched': '25 Sep 2025', 'registration-deadline': None, 'deadline': '17 Dec 2025', 'prize': '$50,000', 'platform': 'Kaggle', 'sponsor': 'The National Football League', 'conference': None, 'conference_year': None}, {'name': 'NFL Big Data Bowl 2026 - Prediction', 'url': 'https://www.kaggle.com/competitions/nfl-big-data-bowl-2026-prediction?ref=mlcontests', 'tags': ['football', 'sports', 'custom metric'], 'launched': '25 Sep 2025', 'registration-deadline': '26 Nov 2025', 'deadline': '3 Dec 2025', 'prize': '$50,000', 'platform': 'Kaggle', 'sponsor': 'The National Football League', 'conference': None, 'conference_year': None}]```