### PR TITLE
Add competition: The Gemma 4 Good Hackathon

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -6166,6 +6166,23 @@
       "sponsor": "ARC Prize",
       "conference": null,
       "conference_year": null
+    },
+    {
+      "name": "The Gemma 4 Good Hackathon",
+      "url": "https://www.kaggle.com/competitions/gemma-4-good-hackathon?ref=mlcontests",
+      "tags": [
+        "artificial intelligence",
+        "tabular",
+        "text"
+      ],
+      "launched": "2 Apr 2026",
+      "registration-deadline": null,
+      "deadline": "18 May 2026",
+      "prize": "$200,000",
+      "platform": "Kaggle",
+      "sponsor": "Google DeepMind",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -6168,12 +6168,12 @@
       "conference_year": null
     },
     {
-      "name": "The Gemma 4 Good Hackathon",
+      "name": "Use Gemma 4 Models to Solve Real-World Problems",
       "url": "https://www.kaggle.com/competitions/gemma-4-good-hackathon?ref=mlcontests",
       "tags": [
-        "artificial intelligence",
-        "tabular",
-        "text"
+        "hackathon",
+        "llm",
+        "subjective"
       ],
       "launched": "2 Apr 2026",
       "registration-deadline": null,


### PR DESCRIPTION
Competition: 

```{'name': 'The Gemma 4 Good Hackathon', 'url': 'https://www.kaggle.com/competitions/gemma-4-good-hackathon?ref=mlcontests', 'tags': ['artificial intelligence', 'tabular', 'text'], 'launched': '2 Apr 2026', 'registration-deadline': None, 'deadline': '18 May 2026', 'prize': '$200,000', 'platform': 'Kaggle', 'sponsor': 'Google DeepMind', 'conference': None, 'conference_year': None}```