### PR TITLE
Add competition: The 2026 NeuroGolf Championship

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -6264,14 +6264,14 @@
       "conference_year": null
     },
     {
-      "name": "The 2026 NeuroGolf Championship",
+      "name": "Build Tiny Neural Nets to Solve Visual Reasoning Tasks",
       "url": "https://www.kaggle.com/competitions/neurogolf-2026?ref=mlcontests",
       "tags": [
-        "golf",
-        "artificial intelligence",
-        "neural networks",
-        "optimization",
-        "custom metric"
+        "llm",
+        "efficiency",
+        "measurable",
+        "supervised",
+        "deep learning"
       ],
       "launched": "15 Apr 2026",
       "registration-deadline": "8 Jul 2026",
@@ -6279,8 +6279,8 @@
       "prize": "$50,000",
       "platform": "Kaggle",
       "sponsor": "The Neurosynthetic Research Institute",
-      "conference": null,
-      "conference_year": null
+      "conference": "IJCAI-ECAI,
+      "conference_year": 2026
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -6262,6 +6262,25 @@
       "sponsor": "Google DeepMind",
       "conference": null,
       "conference_year": null
+    },
+    {
+      "name": "The 2026 NeuroGolf Championship",
+      "url": "https://www.kaggle.com/competitions/neurogolf-2026?ref=mlcontests",
+      "tags": [
+        "golf",
+        "artificial intelligence",
+        "neural networks",
+        "optimization",
+        "custom metric"
+      ],
+      "launched": "15 Apr 2026",
+      "registration-deadline": "8 Jul 2026",
+      "deadline": "15 Jul 2026",
+      "prize": "$50,000",
+      "platform": "Kaggle",
+      "sponsor": "The Neurosynthetic Research Institute",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -6279,7 +6279,7 @@
       "prize": "$50,000",
       "platform": "Kaggle",
       "sponsor": "The Neurosynthetic Research Institute",
-      "conference": "IJCAI-ECAI,
+      "conference": "IJCAI-ECAI",
       "conference_year": 2026
     }
   ]


### PR DESCRIPTION
Competition: 

```{'name': 'The 2026 NeuroGolf Championship', 'url': 'https://www.kaggle.com/competitions/neurogolf-2026?ref=mlcontests', 'tags': ['golf', 'artificial intelligence', 'neural networks', 'optimization', 'custom metric'], 'launched': '15 Apr 2026', 'registration-deadline': '8 Jul 2026', 'deadline': '15 Jul 2026', 'prize': '$50,000', 'platform': 'Kaggle', 'sponsor': 'The Neurosynthetic Research Institute', 'conference': None, 'conference_year': None}```