### PR TITLE
Add competition: Orbit Wars

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -6281,6 +6281,24 @@
       "sponsor": "The Neurosynthetic Research Institute",
       "conference": "IJCAI-ECAI",
       "conference_year": 2026
+    },
+    {
+      "name": "Orbit Wars",
+      "url": "https://www.kaggle.com/competitions/orbit-wars?ref=mlcontests",
+      "tags": [
+        "games",
+        "artificial intelligence",
+        "reinforcement learning",
+        "custom metric"
+      ],
+      "launched": "16 Apr 2026",
+      "registration-deadline": "16 Jun 2026",
+      "deadline": "23 Jun 2026",
+      "prize": "$50,000",
+      "platform": "Kaggle",
+      "sponsor": "Kaggle",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -6283,13 +6283,14 @@
       "conference_year": 2026
     },
     {
-      "name": "Orbit Wars",
+      "name": "Create Bots to Play a Space-Based 2D Strategy Game",
       "url": "https://www.kaggle.com/competitions/orbit-wars?ref=mlcontests",
       "tags": [
-        "games",
-        "artificial intelligence",
+        "game",
+        "pvp",
         "reinforcement learning",
-        "custom metric"
+        "measurable",
+        
       ],
       "launched": "16 Apr 2026",
       "registration-deadline": "16 Jun 2026",

--- a/competitions.json
+++ b/competitions.json
@@ -6289,8 +6289,7 @@
         "game",
         "pvp",
         "reinforcement learning",
-        "measurable",
-        
+        "measurable"        
       ],
       "launched": "16 Apr 2026",
       "registration-deadline": "16 Jun 2026",


### PR DESCRIPTION
Competition: 

```{'name': 'Orbit Wars', 'url': 'https://www.kaggle.com/competitions/orbit-wars?ref=mlcontests', 'tags': ['games', 'artificial intelligence', 'reinforcement learning', 'custom metric'], 'launched': '16 Apr 2026', 'registration-deadline': '16 Jun 2026', 'deadline': '23 Jun 2026', 'prize': '$50,000', 'platform': 'Kaggle', 'sponsor': 'Kaggle', 'conference': None, 'conference_year': None}```