### PR TITLE
Add competition: ROGII - Wellbore Geology Prediction

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -6301,13 +6301,14 @@
       "conference_year": null
     },
     {
-      "name": "ROGII - Wellbore Geology Prediction",
+      "name": "Predict Geology in Horizontal Subsurface Segments",
       "url": "https://www.kaggle.com/competitions/rogii-wellbore-geology-prediction?ref=mlcontests",
       "tags": [
-        "geology",
+        "geo",
         "multimodal",
-        "evaluation",
-        "mean squared error"
+        "regression",
+        "supervised:,
+        "measurable"
       ],
       "launched": "5 May 2026",
       "registration-deadline": "29 Jul 2026",

--- a/competitions.json
+++ b/competitions.json
@@ -6307,7 +6307,7 @@
         "geo",
         "multimodal",
         "regression",
-        "supervised:,
+        "supervised",
         "measurable"
       ],
       "launched": "5 May 2026",

--- a/competitions.json
+++ b/competitions.json
@@ -6289,7 +6289,7 @@
         "game",
         "pvp",
         "reinforcement learning",
-        "measurable"        
+        "measurable"
       ],
       "launched": "16 Apr 2026",
       "registration-deadline": "16 Jun 2026",
@@ -6297,6 +6297,24 @@
       "prize": "$50,000",
       "platform": "Kaggle",
       "sponsor": "Kaggle",
+      "conference": null,
+      "conference_year": null
+    },
+    {
+      "name": "ROGII - Wellbore Geology Prediction",
+      "url": "https://www.kaggle.com/competitions/rogii-wellbore-geology-prediction?ref=mlcontests",
+      "tags": [
+        "geology",
+        "multimodal",
+        "evaluation",
+        "mean squared error"
+      ],
+      "launched": "5 May 2026",
+      "registration-deadline": "29 Jul 2026",
+      "deadline": "5 Aug 2026",
+      "prize": "$50,000",
+      "platform": "Kaggle",
+      "sponsor": "ROGII",
       "conference": null,
       "conference_year": null
     }


### PR DESCRIPTION
Competition: 

```{'name': 'ROGII - Wellbore Geology Prediction', 'url': 'https://www.kaggle.com/competitions/rogii-wellbore-geology-prediction?ref=mlcontests', 'tags': ['geology', 'multimodal', 'evaluation', 'mean squared error'], 'launched': '5 May 2026', 'registration-deadline': '29 Jul 2026', 'deadline': '5 Aug 2026', 'prize': '$50,000', 'platform': 'Kaggle', 'sponsor': 'ROGII', 'conference': None, 'conference_year': None}```