### PR TITLE
Add ADIA Lab Structural Break Challenge Real Time competition

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -4,12 +4,11 @@
       "name": "Detect Structural Breaks in Real-Time Time Series Data",
       "url": "https://hub.crunchdao.com/competitions/structural-break-real-time?ref=mlcontests",
       "tags": [
-        "supervised",
-        "real-time",
+        "climate",
+        "finance",
+        "healthcare",
         "timeseries",
-        "forecasting",
-        "measurable",
-        "finance"
+        "forecasting"
       ],
       "launched": "6 May 2026",
       "registration-deadline": "31 Dec 2026",

--- a/competitions.json
+++ b/competitions.json
@@ -103,8 +103,8 @@
       "prize": "$12,000",
       "platform": "CrunchDAO",
       "sponsor": "Eric and Wendy Schmidt Center",
-      "conference": null,
-      "conference_year": null
+      "conference": "https://events.zoom.us/egj/AviNQoyXkI53omXr5K-Nm-7HEWwUbO72ISftYGti-zP4qZJg7fJm~A11jVpJ_Mxa68cex-0qgYciyiK1UbB6gj-i8wlyc2yYc3AzUtV-DoqsjugKJQ",
+      "conference_year": 2026
     },
     {
       "name": "Predict Cross-sectional Equity Returns",
@@ -144,8 +144,8 @@
       "prize": "$12,000",
       "platform": "CrunchDAO",
       "sponsor": "Eric and Wendy Schmidt Center",
-      "conference": null,
-      "conference_year": null
+      "conference": "https://events.zoom.us/egj/AviNQoyXkI53omXr5K-Nm-7HEWwUbO72ISftYGti-zP4qZJg7fJm~A11jVpJ_Mxa68cex-0qgYciyiK1UbB6gj-i8wlyc2yYc3AzUtV-DoqsjugKJQ",
+      "conference_year": 2026
     },
     {
       "name": "Falcon: Price-Like Timeseries Forecasting",

--- a/competitions.json
+++ b/competitions.json
@@ -1,6 +1,26 @@
 {
   "data": [
     {
+      "name": "Detect Structural Breaks in Real-Time Time Series Data",
+      "url": "https://hub.crunchdao.com/competitions/structural-break-real-time?ref=mlcontests",
+      "tags": [
+        "supervised",
+        "real-time",
+        "timeseries",
+        "forecasting",
+        "measurable",
+        "finance"
+      ],
+      "launched": "6 May 2026",
+      "registration-deadline": "31 Dec 2026",
+      "deadline": "17 Sep 2026",
+      "prize": "$100,000",
+      "platform": "CrunchDAO",
+      "sponsor": "ADIA Lab",
+      "conference": null,
+      "conference_year": null
+    },
+    {
       "name": "Foundation Models for General CT Image Diagnosis",
       "url": "https://www.codabench.org/competitions/12650/?ref=mlcontests",
       "tags": [

--- a/competitions.json
+++ b/competitions.json
@@ -128,26 +128,6 @@
       "conference_year": null
     },
     {
-      "name": "Detect Structural Breaks in Time Series Data",
-      "url": "https://hub.crunchdao.com/competitions/structural-break-open-benchmark?ref=mlcontests",
-      "tags": [
-        "supervised",
-        "tabular",
-        "timeseries",
-        "forecasting",
-        "measurable",
-        "finance"
-      ],
-      "launched": "18 Dec 2025",
-      "registration-deadline": "31 Dec 2026",
-      "deadline": "31 Dec 2026",
-      "prize": "$24,000",
-      "platform": "CrunchDAO",
-      "sponsor": "ADIA Lab",
-      "conference": null,
-      "conference_year": null
-    },
-    {
       "name": "Identify Genes Driving Metabolic Diseases (Part 1)",
       "url": "https://hub.crunchdao.com/competitions/broad-obesity-1?ref=mlcontests",
       "tags": [


### PR DESCRIPTION
This PR add a new edition of the Structural Break challenge, and we deprecated the old one, so I removed it.

I also updated the Obesity ML Challenge from earlier this year to include the link to their Symposium.