### PR TITLE
Add competition: The Pokémon Company - PTCG AI Battle Challenge Strategy

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -6836,21 +6836,26 @@
       "conference-year": null
     },
     {
-      "name": "The Pokémon Company - PTCG AI Battle Challenge Strategy",
+      "name": "Develop and Explain Pokemon Card Battle Agents",
       "url": "https://www.kaggle.com/competitions/pokemon-tcg-ai-battle-challenge-strategy?ref=mlcontests",
       "tags": [
-        "games",
-        "artificial intelligence",
-        "reinforcement learning"
+        "pvp",
+        "game",
+        "reinforcement learning",
+        "subjective",
+        "hackathon",
+        "writing"
       ],
       "launched": "16 Jun 2026",
       "registration-deadline": "6 Sep 2026",
       "deadline": "13 Sep 2026",
       "prize": "$240,000",
       "platform": "Kaggle",
-      "sponsor": "The Pokémon Company - PTCGABC Team",
+      "sponsor": "The Pokémon Company",
       "conference": null,
-      "conference_year": null
+      "conference_year": null,
+      "additional_urls": [
+        "https://www.kaggle.com/competitions/pokemon-tcg-ai-battle"
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -6826,12 +6826,31 @@
       ],
       "launched": "19 May 2025",
       "deadline": "17 Aug 2026",
-      "additional_urls": ["https://xprize.devpost.com/"],
+      "additional_urls": [
+        "https://xprize.devpost.com/"
+      ],
       "prize": "$2,000,000",
       "platform": "Devpost",
       "sponsor": "Google",
       "conference": null,
       "conference-year": null
+    },
+    {
+      "name": "The Pokémon Company - PTCG AI Battle Challenge Strategy",
+      "url": "https://www.kaggle.com/competitions/pokemon-tcg-ai-battle-challenge-strategy?ref=mlcontests",
+      "tags": [
+        "games",
+        "artificial intelligence",
+        "reinforcement learning"
+      ],
+      "launched": "16 Jun 2026",
+      "registration-deadline": "6 Sep 2026",
+      "deadline": "13 Sep 2026",
+      "prize": "$240,000",
+      "platform": "Kaggle",
+      "sponsor": "The Pokémon Company - PTCGABC Team",
+      "conference": null,
+      "conference_year": null
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -6856,6 +6856,7 @@
       "conference_year": null,
       "additional_urls": [
         "https://www.kaggle.com/competitions/pokemon-tcg-ai-battle"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Competition: 

```{'name': 'The Pokémon Company - PTCG AI Battle Challenge Strategy', 'url': 'https://www.kaggle.com/competitions/pokemon-tcg-ai-battle-challenge-strategy?ref=mlcontests', 'tags': ['games', 'artificial intelligence', 'reinforcement learning'], 'launched': '16 Jun 2026', 'registration-deadline': '6 Sep 2026', 'deadline': '13 Sep 2026', 'prize': '$240,000', 'platform': 'Kaggle', 'sponsor': 'The Pokémon Company - PTCGABC Team', 'conference': None, 'conference_year': None}```