### PR TITLE
Add The Email Game competition

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -7031,6 +7031,28 @@
       "conference": null,
       "conference-year": null,
       "additional_urls": []
+    },
+    {
+      "name": "The Email Game",
+      "url": "https://theemailgame.com/?ref=mlcontests",
+      "tags": [
+        "agents",
+        "llm",
+        "nlp",
+        "game",
+        "security",
+        "pvp"
+      ],
+      "launched": null,
+      "registration-deadline": null,
+      "deadline": "1 Aug 2026",
+      "added": "22 Jul 2026",
+      "prize": "$1,700",
+      "platform": "Independent",
+      "sponsor": "WithAI",
+      "conference": null,
+      "conference-year": null,
+      "additional_urls": []
     }
   ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -7033,7 +7033,7 @@
       "additional_urls": []
     },
     {
-      "name": "The Email Game",
+      "name": "Build Smart, Reliable Email Agents",
       "url": "https://theemailgame.com/?ref=mlcontests",
       "tags": [
         "agents",
@@ -7041,7 +7041,8 @@
         "nlp",
         "game",
         "security",
-        "pvp"
+        "pvp",
+        "hackathon"
       ],
       "launched": null,
       "registration-deadline": null,


### PR DESCRIPTION
Adds The Email Game, a free AI-agent competition. Deadline 1 Aug 2026, $1,700 cash prize pool ($1,000/$500/$200). Agents compete over simulated email. Meets inclusion criteria: set deadline, publicly viewable without signup, no entry fee, and $1,700 cash > the $1,000 minimum.